### PR TITLE
Fixed footer overlapping in home page

### DIFF
--- a/src/components/common/Footer.js
+++ b/src/components/common/Footer.js
@@ -16,7 +16,7 @@ function Footer() {
     html.offsetHeight
   );
   return (
-    <footer className="ftr" style={{ top: `${docHeight + 150}px` }}>
+    <footer className="ftr">
       <div className="row">
         <div className="col">
           <div className="text-left">


### PR DESCRIPTION
*Also fixes the huge gap between the content and the footer in the login and sign up pages*

<!-- To put a tick in the boxes below, use X (uppercase X) to mark -->

**Does your PR solve any issues/bugs opened or raised in this repo?**

- [ ] Yes
- [x] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No**: N/A

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [ ] Bug fix
- [ ] Feature Update
- [ ] Page addition
- [x] UI Fix
- [ ] Other

**Description of what you did:**

Removed the `top` css property for the Footer which was causing overlapping of content in the home page and a huge gap in the log in and sign up pages.

**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [ ] Yes
- [ ] No
- [x] N/A
