### PR TITLE
Fixed newuser scrollbar issue

### DIFF
--- a/src/styles/newuser.css
+++ b/src/styles/newuser.css
@@ -57,7 +57,7 @@
   font-size: 30px;
   line-height: 45px;
   color: #222222;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .radio-buttons {


### PR DESCRIPTION
**Does your PR solve any issues/bugs opened or raised in this repo?**

- [x] Yes
- [ ] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**: Scroll bar present when not necessary on "Welcome to Def Hacks Learn! To get started, please answer a few questions about yourself." page.

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [ ] Bug fix
- [ ] Feature Update
- [ ] Page addition
- [x] UI Fix
- [ ] Other

**Description of what you did:**

Set the overflow-y to `auto` instead of `scroll` for the `lower-box`. The scroll bar does not show up unless necessary. The page is still not responsive. It needs work.

**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [ ] Yes
- [x] No
