### PR TITLE
Added edit button for editing user details

### DIFF
--- a/src/pages/ExistAccount.js
+++ b/src/pages/ExistAccount.js
@@ -3,6 +3,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import Swal from 'sweetalert2';
 import { Row, Col } from 'react-bootstrap';
 import { useHistory } from 'react-router-dom';
+import EditIcon from '@material-ui/icons/Edit';
 
 import '../styles/exist.css';
 import firebase from '../components/firebase/base';
@@ -20,7 +21,7 @@ function ExistAccount() {
       setUsername(user.displayName);
       setEmail(user.email);
     }
-  });
+  }, [user, history]);
 
   const ID = user.uid;
   const [USERNAME, setUsername] = useState('user');
@@ -188,14 +189,37 @@ function ExistAccount() {
           <div className="content-box-2">
             <div className="box-title-acc">Account Information</div>
             <div className="box-content-acc-text">
-              <p onClick={() => changeSetting('username')}>
-                Username: {USERNAME}
+              <p>
+                Username: {USERNAME}{' '}
+                <span
+                  className="box-content-acc-edit-text"
+                  onClick={() => changeSetting('username')}
+                >
+                  <EditIcon className="edit-icon" />
+                  Edit
+                </span>
               </p>
-              <p onClick={() => changeSetting('email')}>Email: {EMAIL}</p>
+              <p>
+                Email: {EMAIL}{' '}
+                <span
+                  className="box-content-acc-edit-text"
+                  onClick={() => changeSetting('email')}
+                >
+                  <EditIcon className="edit-icon" />
+                  Edit
+                </span>
+              </p>
               <p>Location: USA</p>
               <div>
-                <p onClick={() => changeSetting('password')}>
-                  Password: {passwordDOMElement(PASSWORD)}
+                <p>
+                  Password: {passwordDOMElement(PASSWORD)}{' '}
+                  <span
+                    className="box-content-acc-edit-text"
+                    onClick={() => changeSetting('password')}
+                  >
+                    <EditIcon className="edit-icon" />
+                    Edit
+                  </span>
                 </p>
               </div>
             </div>

--- a/src/styles/exist.css
+++ b/src/styles/exist.css
@@ -187,12 +187,26 @@ body {
   color: #000000;
 }
 
+.box-content-acc-edit-text {
+  font-family: IBM Plex Mono;
+  font-style: normal;
+  font-weight: 100;
+  font-size: 1.2vw;
+  line-height: 1rem;
+  color: #3a3a3a;
+  cursor: pointer;
+}
+
+.edit-icon {
+  font-size: 1.3vw!important;
+  padding-bottom: 0.1vw;
+}
+
 .box-title-acc {
   font-family: IBM Plex Mono;
   font-weight: 600;
   font-size: 3vw;
   text-align: center;
-
   color: #000000;
 }
 


### PR DESCRIPTION
**Does your PR solve any issues/bugs opened or raised in this repo?**

- [x] Yes
- [ ] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**:  [Edit email on /account should have a separate button or atleast have a hand mouse pointer on hover. Same for username and password.](https://github.com/Def-Hacks-CS-Outreach/def-hacks-learn/projects/2#card-51119851)

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [x] Bug fix
- [x] Feature Update
- [ ] Page addition
- [x] UI Fix
- [ ] Other

**Description of what you did:**

Added an edit button for editting user details. Earlier, on click of the user details i.e, the email or username or password, the popup for edit was shown. Now there is a button for it which is better UX.

**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [x] Yes
- [ ] No
