### PR TITLE
Fixed error messages displayed while updating user details

### DIFF
--- a/src/pages/ExistAccount.js
+++ b/src/pages/ExistAccount.js
@@ -73,8 +73,13 @@ function ExistAccount() {
                       setUsername(newUsername);
                     })
                     .catch(function (error) {
-                      console.log(error);
-                      Swal.fire(error, '', 'error');
+                      Swal.fire(
+                        error.message
+                          ? error.message
+                          : 'Error occured while updating username',
+                        '',
+                        'error'
+                      );
                     });
                 }
               }
@@ -109,7 +114,13 @@ function ExistAccount() {
                       setPassword(pwToUpdate[1]);
                     })
                     .catch((err) => {
-                      Swal.fire(err, '', 'error');
+                      Swal.fire(
+                        err.message
+                          ? err.message
+                          : 'Error occured while updating password',
+                        '',
+                        'error'
+                      );
                     });
                 } else {
                   Swal.fire("Password doesn't match!", '', 'error');
@@ -135,7 +146,6 @@ function ExistAccount() {
             if (result.value) {
               var newEmail = result.value[0];
 
-              // TASK FOR BACKEND: Make sure email isn't already taken in the account database
               if (newEmail !== null && newEmail !== '') {
                 if (newEmail !== EMAIL) {
                   if (emailValid(newEmail)) {
@@ -148,7 +158,13 @@ function ExistAccount() {
                         setEmail(newEmail);
                       })
                       .catch((err) => {
-                        Swal.fire(err, '', 'error');
+                        Swal.fire(
+                          err.message
+                            ? err.message
+                            : 'Error occured while updating email',
+                          '',
+                          'error'
+                        );
                       });
                   } else {
                     Swal.fire('Invalid Email!', '', 'error');


### PR DESCRIPTION
**Does your PR solve any issues/bugs opened or raised in this repo?**

- [ ] Yes
- [x] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**: N/A

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [x] Bug fix
- [ ] Feature Update
- [ ] Page addition
- [x] UI Fix
- [ ] Other

**Description of what you did:**

When the user updates his details from `/account` and does an invalid update i.e, invalid password, or existing email, etc. The pop up did not display the error message, instead gave an empty pop up. Now the appropriate error messages are displayed in the pop up.

Before - 
![old](https://user-images.githubusercontent.com/52544819/102906555-cd99e780-449a-11eb-96d8-f2b1afc47fa2.png)

After - 

![new](https://user-images.githubusercontent.com/52544819/102906659-f28e5a80-449a-11eb-8226-92c455de182f.png)


**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [ ] Yes
- [ ] No
- [x] N/A
