### PR TITLE
Redirect new Google auth users to /newuser

### DIFF
--- a/src/components/authscreens/Signup.js
+++ b/src/components/authscreens/Signup.js
@@ -56,10 +56,14 @@ const SignUp = ({ history }) => {
   const registerWithGoogle = () => {
     firebase
       .signInWithGoogle()
-      .then(() => {
+      .then((result) => {
         setEmail('');
         setPassword('');
-        history.push('/dashboard');
+        if (result.additionalUserInfo.isNewUser) {
+          history.push('/newuser');
+        } else {
+          history.push('/dashboard');
+        }
       })
       .catch((err) => {
         setError(err.message);


### PR DESCRIPTION
**Does your PR solve any issues/bugs opened or raised in this repo?**

- [x] Yes
- [ ] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**: [Google Auth Sign Up](https://github.com/Def-Hacks-CS-Outreach/def-hacks-learn/projects/2#card-51688939)

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [x] Bug fix
- [ ] Feature Update
- [ ] Page addition
- [ ] UI Fix
- [ ] Other

**Description of what you did:**

When an user signs up using Google Auth, he/she is redirected to `/dashboard` instead of the `/newuser` route unlike the other password based users. Now, new Google auth users will be redirected to `/newuser` if logged in for the first time.

**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [x] Yes
- [ ] No
