### PR TITLE
Restrict new users pages only to first login

### DIFF
--- a/src/pages/NewUser.js
+++ b/src/pages/NewUser.js
@@ -15,6 +15,10 @@ function NewUser() {
   useEffect(() => {
     if (!user) {
       history.push('/signin');
+    } else if (user.metadata) {
+      if (user.metadata.creationTime !== user.metadata.lastSignInTime) {
+        history.push('/dashboard');
+      }
     }
   });
 

--- a/src/pages/NewUserCourses.js
+++ b/src/pages/NewUserCourses.js
@@ -51,6 +51,10 @@ const NewUserCourses = () => {
   useEffect(() => {
     if (!user) {
       history.push('/signin');
+    } else if (user.metadata) {
+      if (user.metadata.creationTime !== user.metadata.lastSignInTime) {
+        history.push('/dashboard');
+      }
     }
   });
 

--- a/src/pages/NewUserFinal.js
+++ b/src/pages/NewUserFinal.js
@@ -15,6 +15,10 @@ function NewUserFinal() {
   useEffect(() => {
     if (!user) {
       history.push('/signin');
+    } else if (user.metadata) {
+      if (user.metadata.creationTime !== user.metadata.lastSignInTime) {
+        history.push('/dashboard');
+      }
     }
   });
 


### PR DESCRIPTION
Does your PR solve any issues/bugs opened or raised in this repo?

- [ ] Yes
- [x] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**: N/A

Is it a bug fix, security fix, feature update, UI Update or other?

- [ ] Backend Fix
- [ ] Bug fix
- [x] Feature Update
- [ ] Page addition
- [ ] UI Fix
- [ ] Other

Description of what you did:

Pages such as `/newuser`, `/newusercourses` and `/newuserfinal` were accessible even when the user was not *new*. Now the user's created time and last log in time is compared to see if the user is logged for the first time. If it is not the first time, the users are redirected to `/dashboard`.

If page addition is marked, mention the page name here:

N/A

Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)

- [ ] Yes
- [ ] No
- [x] N/A
