### PR TITLE
Display toast after logout

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -2,6 +2,8 @@ import React, { useContext, useState } from 'react';
 import { Navbar, Nav, NavDropdown } from 'react-bootstrap';
 import SearchIcon from '@material-ui/icons/Search';
 import { useHistory, Link } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import '../../styles/navbar.css';
 import Autosuggest from 'react-autosuggest';
 import firebase from '../firebase/base';
@@ -124,6 +126,15 @@ function Navigation() {
                 <NavDropdown.Item
                   onClick={() => {
                     firebase.logout();
+                    toast.success('You have successfully logged out!', {
+                      position: 'top-right',
+                      autoClose: 3000,
+                      hideProgressBar: true,
+                      closeOnClick: true,
+                      pauseOnHover: true,
+                      draggable: true,
+                      progress: undefined,
+                    });
                     history.push('/');
                   }}
                 >
@@ -143,6 +154,17 @@ function Navigation() {
           </NavDropdown>
         </Nav>
       </Navbar>
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar
+        newestOnTop
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
     </>
   );
 }


### PR DESCRIPTION
**Does your PR solve any issues/bugs opened or raised in this repo?**

- [x] Yes
- [ ] No

If you've mentioned **Yes** above, then mention the Issue no here (with #), else ignore it:

**Issue No or name**:  [User logout](https://github.com/Def-Hacks-CS-Outreach/def-hacks-learn/projects/2#card-51688862)

**Is it a bug fix, security fix, feature update, UI Update or other?**

- [ ] Backend Fix
- [ ] Bug fix
- [x] Feature Update
- [ ] Page addition
- [x] UI Fix
- [ ] Other

**Description of what you did:**

There is no indication of when the user is logged out other than redirection to home page. If the user logs out from the home page, there is no indication. A toast that pops up indicating the user has logged out.
![logout-toast](https://user-images.githubusercontent.com/52544819/103028687-4625a480-457e-11eb-8023-570202278f51.png)


**If page addition is marked, mention the page name here:**

N/A

**Have you notified this PR in the issue? [OPTIONAL] (so that we can check in case of issue fix)**

- [x] Yes
- [ ] No
